### PR TITLE
Fix typename parsing

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -57,4 +57,4 @@ Fixpoint :
 Type :
   NUMTY           { TyNum }
 | BOOLTY          { TyBool }
-| Type ARROW Type { TyFun ($1, $3) }
+| LPAREN Type ARROW Type RPAREN { TyFun ($2, $4) }


### PR DESCRIPTION
Change the grammar of type section of lambda-expression and
mu-expression so that `(lambda f:(num->num).(f 1))` is able to parse,
for example.
